### PR TITLE
feat: support local k8s clusters

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 import { App, Chart } from 'cdk8s';
-import { DeboredApp } from '../lib/index';
+import { DeboredApp, IngressType } from '../lib/index';
 
 class MyChart extends Chart {
   constructor(scope: Construct, name: string) {
@@ -10,13 +10,18 @@ class MyChart extends Chart {
       image: 'nginx',
     });
   
-    new DeboredApp(this, 'with-options', {
+    new DeboredApp(this, 'with-full-options', {
       namespace: 'default',
       image: 'nginx',
       defaultReplicas: 2,
       port: 80,
       containerPort: 80,
       autoScale: true,
+      ingress: IngressType.NGINX_INGRESS,
+      resources: {
+        limits: { cpu: '400m', memory: '512Mi' },
+        requests: { cpu: '200m', memory: '256Mi' },
+      },
     });
   }
 }

--- a/test/__snapshots__/debored-app.test.js.snap
+++ b/test/__snapshots__/debored-app.test.js.snap
@@ -104,13 +104,13 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "LoadBalancer",
+      "type": "ClusterIP",
     },
   },
 ]
 `;
 
-exports[`"ingress" installs an nginx-based ingress controller 1`] = `
+exports[`"ingress == NGINX_INGRESS" uses an nginx ingress 1`] = `
 Array [
   Object {
     "apiVersion": "apps/v1",
@@ -211,6 +211,78 @@ Array [
 ]
 `;
 
+exports[`"ingress == SERVICE_LOADBALANCER" uses a LoadBalancer service 1`] = `
+Array [
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-myapp-deployment-deployment-c1cb76c8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "testmyappD19744AC",
+        },
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "testmyappD19744AC",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "image": "myimage",
+              "imagePullPolicy": "Always",
+              "name": "app",
+              "ports": Array [
+                Object {
+                  "containerPort": 8080,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "400m",
+                  "memory": "512Mi",
+                },
+                "requests": Object {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "name": "test-myapp-exposable-service-568386d8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 80,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": Object {
+        "app": "testmyappD19744AC",
+      },
+      "type": "LoadBalancer",
+    },
+  },
+]
+`;
+
 exports[`"namespace" controls the k8s namespace to use" 1`] = `
 Array [
   Object {
@@ -277,7 +349,7 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "LoadBalancer",
+      "type": "ClusterIP",
     },
   },
 ]
@@ -349,7 +421,7 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "LoadBalancer",
+      "type": "ClusterIP",
     },
   },
 ]
@@ -421,7 +493,7 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "LoadBalancer",
+      "type": "ClusterIP",
     },
   },
 ]

--- a/test/__snapshots__/debored-app.test.js.snap
+++ b/test/__snapshots__/debored-app.test.js.snap
@@ -104,6 +104,150 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
+      "type": "LoadBalancer",
+    },
+  },
+]
+`;
+
+exports[`"defaultReplicas" can be used to control the number of replicas 1`] = `
+Array [
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-myapp-deployment-deployment-c1cb76c8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "replicas": 10,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "testmyappD19744AC",
+        },
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "testmyappD19744AC",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "image": "myimage",
+              "imagePullPolicy": "Always",
+              "name": "app",
+              "ports": Array [
+                Object {
+                  "containerPort": 8080,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "400m",
+                  "memory": "512Mi",
+                },
+                "requests": Object {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "name": "test-myapp-exposable-service-568386d8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 80,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": Object {
+        "app": "testmyappD19744AC",
+      },
+      "type": "LoadBalancer",
+    },
+  },
+]
+`;
+
+exports[`"ingress == CLUSTER_IP" uses a ClusterIP service 1`] = `
+Array [
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-myapp-deployment-deployment-c1cb76c8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "testmyappD19744AC",
+        },
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "testmyappD19744AC",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "image": "myimage",
+              "imagePullPolicy": "Always",
+              "name": "app",
+              "ports": Array [
+                Object {
+                  "containerPort": 8080,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "400m",
+                  "memory": "512Mi",
+                },
+                "requests": Object {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "name": "test-myapp-exposable-service-568386d8",
+      "namespace": "default",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 80,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": Object {
+        "app": "testmyappD19744AC",
+      },
       "type": "ClusterIP",
     },
   },
@@ -211,78 +355,6 @@ Array [
 ]
 `;
 
-exports[`"ingress == SERVICE_LOADBALANCER" uses a LoadBalancer service 1`] = `
-Array [
-  Object {
-    "apiVersion": "apps/v1",
-    "kind": "Deployment",
-    "metadata": Object {
-      "name": "test-myapp-deployment-deployment-c1cb76c8",
-      "namespace": "default",
-    },
-    "spec": Object {
-      "replicas": 1,
-      "selector": Object {
-        "matchLabels": Object {
-          "app": "testmyappD19744AC",
-        },
-      },
-      "template": Object {
-        "metadata": Object {
-          "labels": Object {
-            "app": "testmyappD19744AC",
-          },
-        },
-        "spec": Object {
-          "containers": Array [
-            Object {
-              "image": "myimage",
-              "imagePullPolicy": "Always",
-              "name": "app",
-              "ports": Array [
-                Object {
-                  "containerPort": 8080,
-                },
-              ],
-              "resources": Object {
-                "limits": Object {
-                  "cpu": "400m",
-                  "memory": "512Mi",
-                },
-                "requests": Object {
-                  "cpu": "200m",
-                  "memory": "256Mi",
-                },
-              },
-            },
-          ],
-        },
-      },
-    },
-  },
-  Object {
-    "apiVersion": "v1",
-    "kind": "Service",
-    "metadata": Object {
-      "name": "test-myapp-exposable-service-568386d8",
-      "namespace": "default",
-    },
-    "spec": Object {
-      "ports": Array [
-        Object {
-          "port": 80,
-          "targetPort": 8080,
-        },
-      ],
-      "selector": Object {
-        "app": "testmyappD19744AC",
-      },
-      "type": "LoadBalancer",
-    },
-  },
-]
-`;
-
 exports[`"namespace" controls the k8s namespace to use" 1`] = `
 Array [
   Object {
@@ -349,79 +421,7 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "ClusterIP",
-    },
-  },
-]
-`;
-
-exports[`"replicas" can be used to control the number of replicas 1`] = `
-Array [
-  Object {
-    "apiVersion": "apps/v1",
-    "kind": "Deployment",
-    "metadata": Object {
-      "name": "test-myapp-deployment-deployment-c1cb76c8",
-      "namespace": "default",
-    },
-    "spec": Object {
-      "replicas": 10,
-      "selector": Object {
-        "matchLabels": Object {
-          "app": "testmyappD19744AC",
-        },
-      },
-      "template": Object {
-        "metadata": Object {
-          "labels": Object {
-            "app": "testmyappD19744AC",
-          },
-        },
-        "spec": Object {
-          "containers": Array [
-            Object {
-              "image": "myimage",
-              "imagePullPolicy": "Always",
-              "name": "app",
-              "ports": Array [
-                Object {
-                  "containerPort": 8080,
-                },
-              ],
-              "resources": Object {
-                "limits": Object {
-                  "cpu": "400m",
-                  "memory": "512Mi",
-                },
-                "requests": Object {
-                  "cpu": "200m",
-                  "memory": "256Mi",
-                },
-              },
-            },
-          ],
-        },
-      },
-    },
-  },
-  Object {
-    "apiVersion": "v1",
-    "kind": "Service",
-    "metadata": Object {
-      "name": "test-myapp-exposable-service-568386d8",
-      "namespace": "default",
-    },
-    "spec": Object {
-      "ports": Array [
-        Object {
-          "port": 80,
-          "targetPort": 8080,
-        },
-      ],
-      "selector": Object {
-        "app": "testmyappD19744AC",
-      },
-      "type": "ClusterIP",
+      "type": "LoadBalancer",
     },
   },
 ]
@@ -493,7 +493,7 @@ Array [
       "selector": Object {
         "app": "testmyappD19744AC",
       },
-      "type": "ClusterIP",
+      "type": "LoadBalancer",
     },
   },
 ]

--- a/test/debored-app.test.ts
+++ b/test/debored-app.test.ts
@@ -1,5 +1,5 @@
 import { Testing, Chart } from 'cdk8s';
-import { DeboredApp } from '../lib';
+import { DeboredApp, IngressType } from '../lib';
 
 test('minimal configuration', () => {
   // GIVEN
@@ -45,7 +45,7 @@ test('"autoScale" will define pod autoscaling with sensible configuration', () =
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
-test('"replicas" can be used to control the number of replicas', () => {
+test('"defaultReplicas" can be used to control the number of replicas', () => {
   // GIVEN
   const app = Testing.app();
   const chart = new Chart(app, 'test');
@@ -60,7 +60,7 @@ test('"replicas" can be used to control the number of replicas', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
-test('"ingress" installs an nginx-based ingress controller', () => {
+test('"ingress == CLUSTER_IP" uses a ClusterIP service', () => {
   // GIVEN
   const app = Testing.app();
   const chart = new Chart(app, 'test');
@@ -68,7 +68,22 @@ test('"ingress" installs an nginx-based ingress controller', () => {
   // WHEN
   new DeboredApp(chart, 'myapp', {
     image: 'myimage',
-    ingress: true,
+    ingress: IngressType.CLUSTER_IP,
+  });
+
+  // THEN
+  expect(Testing.synth(chart)).toMatchSnapshot();
+});
+
+test('"ingress == NGINX_INGRESS" uses an nginx ingress', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'test');
+  
+  // WHEN
+  new DeboredApp(chart, 'myapp', {
+    image: 'myimage',
+    ingress: IngressType.NGINX_INGRESS,
   });
 
   // THEN


### PR DESCRIPTION
This PR enables users to specify the Kubernetes service type explicitly. The main use case is to use this library to generate Kubernetes YAMLs for local clusters (created by kind, for example) which don't natively support `LoadBalancer`-typed Kubernetes service.
